### PR TITLE
Fix image not showing due to Cloudflare challenge

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,10 @@
     "chrome_url_overrides": {
         "newtab": "index.html"
     },
-    "permissions": ["storage"],
+    "permissions": ["storage", "cookies", "declarativeNetRequest"],
+    "host_permissions": [
+        "*://*.artic.edu/"
+    ],
     "browser_specific_settings": {
         "gecko": {
             "id": "{63e9ecc7-596d-62ce-00bd-41c2fe3c7fcd}"

--- a/script.js
+++ b/script.js
@@ -17,6 +17,29 @@
     let artworkContainer;
     let viewer;
 
+    chrome.cookies.getAll({ name: 'cf_clearance', domain: 'artic.edu', partitionKey: {} }).then(async cookies => {
+        for (cookie of cookies) {
+            const rules = [{
+                id: 1,
+                priority: 1,
+                action: {
+                    type: 'modifyHeaders',
+                    requestHeaders: [
+                        { header: 'cookie', operation: 'append', value: `cf_clearance=${cookie.value}` }
+                    ]
+                },
+                condition: { urlFilter: '||artic.edu/', resourceTypes: ['image'] }
+            }];
+
+            await chrome.declarativeNetRequest.updateDynamicRules({
+                removeRuleIds: rules.map(rule => rule.id),
+                addRules: rules
+            });
+
+            break;
+        }
+    });
+
     document.addEventListener('DOMContentLoaded', function (event) {
         tombstoneElement = document.getElementById('tombstone');
         titleElement = document.getElementById('title');


### PR DESCRIPTION
Fix #61 

This fixes the issue by using the appropriate cookie from artic.edu. It requires the user to visit the site manually and pass the Cloudflare challenge themself first.